### PR TITLE
Release/1.0.2

### DIFF
--- a/widget/edit.controller.js
+++ b/widget/edit.controller.js
@@ -2,11 +2,11 @@
 (function () {
     angular
         .module('cybersponse')
-        .controller('editFieldsOfInterest101Ctrl', editFieldsOfInterest101Ctrl);
+        .controller('editFieldsOfInterest102Ctrl', editFieldsOfInterest102Ctrl);
 
-    editFieldsOfInterest101Ctrl.$inject = ['$scope', '$uibModalInstance', 'config', '_', '$state', 'Entity', 'widget', 'ViewTemplateService', 'CommonUtils'];
+    editFieldsOfInterest102Ctrl.$inject = ['$scope', '$uibModalInstance', 'config', '_', '$state', 'Entity', 'widget', 'ViewTemplateService', 'CommonUtils'];
 
-    function editFieldsOfInterest101Ctrl($scope, $uibModalInstance, config, _, $state, Entity,  widget, ViewTemplateService, CommonUtils) {
+    function editFieldsOfInterest102Ctrl($scope, $uibModalInstance, config, _, $state, Entity,  widget, ViewTemplateService, CommonUtils) {
         $scope.cancel = cancel;
         $scope.save = save;
         $scope.widget = widget;

--- a/widget/edit.controller.js
+++ b/widget/edit.controller.js
@@ -16,7 +16,7 @@
             columns: [{
                 fields: []
             }],
-            style : 'display-inline-block'
+            style : ''
         }];
 
         $scope.config.excludeFieldsArray = $scope.config.excludeFieldsArray ? $scope.config.excludeFieldsArray : [];
@@ -34,7 +34,7 @@
 
         $scope.module = $state.params.module;
         $scope.applyDefaults = applyDefaults;
-        $scope.config.allReadOnly = true;
+        $scope.config.allReadOnly = false;
         $scope.config.allHighlightMode = true;
         checkReadOnlyAndAllHighlight();
         loadAttributes();

--- a/widget/edit.html
+++ b/widget/edit.html
@@ -13,7 +13,10 @@
                 <label class="control-label" for="formGroupTitle">Title (leave blank for no title)</label>
                 <input class="form-control" type="text" id="formGroupTitle" data-ng-model="config.title" />
             </div>
-
+            <div class="form-group">
+                <label class="control-label" for="rowStyle">Row Style</label>
+                <input class="form-control" type="text" id="rowStyle" data-ng-model="config.rows[0].style" />
+            </div>
             <hr>
             <div>
                 <div class="row margin-bottom-md">
@@ -165,18 +168,17 @@
                         <span
                             data-uib-tooltip="Adds a column named 'Others' that includes all the remaining fields"
                             data-tooltip-append-to-body="true"><i class="icon icon-information font-size-12"></i></span>
-                        <span class="custom-toggle-btn-wrapper edit-toggles pull-right" style="margin-top:-5px">
-                            <span class="custom-toggle-switch-base"
-                                data-ng-class="config.includeAll ? 'custom-toggle-active': 'custom-toggle-inactive'">
-                                <input id="IncludeAll" type="checkbox" name="includeAll" type="checkbox"
-                                    class="custom-toggle-input" data-ng-model="config.includeAll">
-                                <span class="custom-toggle-handle"></span>
-                                <span class="custom-toggle-root"></span>
-                            </span>
-                            <span class="custom-toggle-track"></span>
-                        </span>
+                        <label class="switch switch-pill switch-label switch-success padding-top-md">
+                            <input type="checkbox" class="switch-input" name="IncludeAll"
+                                id="IncludeAll" data-ng-model="config.includeAll"
+                                data-ng-change="$ctrl.changeActiveStatus()">
+                            <span class="switch-slider" data-checked="Yes"
+                                data-unchecked="No"></span>
+                        </label>
                     </span>
                 </div>
+                <hr data-ng-if="!config.includeAll" class="visibility-hidden">
+
                 <div data-ng-if="config.includeAll">
                     <hr class="visibility-hidden">
 

--- a/widget/info.json
+++ b/widget/info.json
@@ -2,12 +2,12 @@
     "name": "fieldsOfInterest",
     "title": "Fields Of Interest",
     "subTitle": "Select fields to display in the detailed view, regardless of the 'Visiblity constraint'",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "published_date": 1679989083,    
     "releaseNotes": "available",
     "metadata": {
         "size": "lg",
-        "help_online":"https://github.com/fortinet-fortisoar/widget-fields-of-interest/blob/release/1.0.1/README.md",
+        "help_online":"https://github.com/fortinet-fortisoar/widget-fields-of-interest/blob/release/1.0.2/README.md",
         "description": "Fields of interest widget displays selected fields for an individual record, in its detail view, in a module, regardless of the visiblity constraint.",
         "pages": [
             "View Panel"
@@ -15,8 +15,8 @@
         "certified": "No",
         "publisher": "Fortinet",
         "snapshots": [
-            "https://repo.fortisoar.fortinet.com/fsr-widgets/fieldsOfInterest-1.0.1/images/edit-fields-of-interest.png",
-            "https://repo.fortisoar.fortinet.com/fsr-widgets/fieldsOfInterest-1.0.1/images/detailed-view.png"
+            "https://repo.fortisoar.fortinet.com/fsr-widgets/fieldsOfInterest-1.0.2/images/edit-fields-of-interest.png",
+            "https://repo.fortisoar.fortinet.com/fsr-widgets/fieldsOfInterest-1.0.2/images/detailed-view.png"
             ],
         "compatibility": [
             "7.3.1"

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -2,11 +2,11 @@
 (function () {
     angular
         .module('cybersponse')
-        .controller('fieldsOfInterest101Ctrl', fieldsOfInterest101Ctrl);
+        .controller('fieldsOfInterest102Ctrl', fieldsOfInterest102Ctrl);
 
-    fieldsOfInterest101Ctrl.$inject = ['$scope', '$state', 'Entity', 'FormEntityService', 'Modules', 'viewTemplate', '$rootScope', '$timeout'];
+    fieldsOfInterest102Ctrl.$inject = ['$scope', '$state', 'Entity', 'FormEntityService', 'Modules', 'viewTemplate', '$rootScope', '$timeout'];
 
-    function fieldsOfInterest101Ctrl($scope, $state, Entity, FormEntityService, Modules, viewTemplate, $rootScope, $timeout) {
+    function fieldsOfInterest102Ctrl($scope, $state, Entity, FormEntityService, Modules, viewTemplate, $rootScope, $timeout) {
         $scope.id = $state.params.id;
         $scope.module = $state.params.module;
         $scope.updateFieldValues = updateFieldValues;


### PR DESCRIPTION
Requirement :
1. Change the toggle button, to make it visible in white theme
2. For JSON type fields, the JSON editor is not displayed properly (Mantis - [0919902])

Fixes:
1. Added a 'row style' option, as in "Edit form group widget" - to give style to the widget 
      eg. display-inline-block, display-block
2.  Changed toggle button

Test:
1. If the row style field is empty, the json viewer is properly visible
2. Toggle button clearly visible in white theme