### PR TITLE
Review/1.1.0

### DIFF
--- a/widget/info.json
+++ b/widget/info.json
@@ -2,7 +2,7 @@
     "name": "fieldsOfInterest",
     "title": "Fields Of Interest",
     "subTitle": "Select fields to display in the detailed view, regardless of the 'Visibility Constraint'",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "published_date": 1679989083,    
     "releaseNotes": "available",
     "metadata": {
@@ -19,7 +19,7 @@
             "https://repo.fortisoar.fortinet.com/fsr-widgets/fieldsOfInterest-1.1.0/images/detailed-view.png"
             ],
         "compatibility": [
-            "7.6.3"
+            "8.0.0"
         ]
     }
 }

--- a/widget/widgetAssets/locales/en.json
+++ b/widget/widgetAssets/locales/en.json
@@ -1,5 +1,5 @@
 {
-    "fsmAlertDetials": {
+    "fieldsOfInterest": {
         "HIDE_EMPTY_FIELDS": "Hide Empty Fields",
         "HIDE_EMPTY_FIELDS_TOOLTIP": "If checked all empty fields will be hidden.",
 

--- a/widget/widgetAssets/locales/fr_fr.json
+++ b/widget/widgetAssets/locales/fr_fr.json
@@ -1,0 +1,37 @@
+{
+  "fieldsOfInterest": {
+    "HIDE_EMPTY_FIELDS": "Masquer les champs vides",
+    "HIDE_EMPTY_FIELDS_TOOLTIP": "Si coché, tous les champs vides seront masqués.",
+
+    "ADD_SECTION": "Ajouter une section",
+    "ALL_INLINE": "Tout en ligne",
+    "ALL_INLINE_TOOLTIP": "Si non coché, tous les champs afficheront un bouton d’édition au lieu d’une modification par clic.",
+    "ALL_READ_ONLY": "Tout en lecture seule",
+    "CLOSE_BTN": "Fermer",
+    "CUSTOM_HTML": "HTML personnalisé",
+    "CUSTOM_VIEW": "Vue personnalisée",
+    "CUSTOM_WIDGET": "Widget personnalisé",
+    "EDIT_TITLE": "Titre (laisser vide pour aucun titre)",
+    "EXCLUDE_FIELDS": "Exclure les champs suivants",
+    "HTML": "HTML",
+    "HTML_PLACEHOLDER": "Ajouter du HTML",
+    "INLINE_EDITOR": "Éditeur en ligne",
+    "INLINE_EDITOR_TOOLTIP": "Si non coché, le champ affichera un bouton d’édition au lieu d’une modification par clic.",
+    "IS_JSON": "Contenu JSON",
+    "READ_ONLY": "Tout en lecture seule",
+    "READ_ONLY_TOOLTIP": "Si coché, tous les champs seront en lecture seule независимо des permissions.",
+    "SAVE_BTN": "Enregistrer",
+    "SELECT_A_WIDGET": "Sélectionner un widget",
+    "SELECT_WIDGET": "Sélectionner un widget",
+    "SHOW_ALL_FIELDS": "Afficher tous les champs restants",
+    "SHOW_FIELDS": "Afficher la case de visibilité des champs",
+    "SHOW_FIELDS_TOOLTIP": "Permet d’afficher la case « Masquer les champs vides » dans la vue détaillée du module",
+    "TITLE": "Titre",
+    "TITLE_TOOLTIP": "Donner un titre à la propriété",
+    "TOOLTIP": "Infobulle",
+    "TOOLTIP_TOOLTIP": "Donner une infobulle à la propriété",
+    "WIDGET_EDIT_TITLE": "Modifier les champs d’intérêt",
+    "WIDGET_HEIGHT": "Hauteur du widget",
+    "WIDGET_HEIGHT_TOOLTIP": "Définir la hauteur de l’éditeur JSON (en px). Valeur minimale : 250 px, maximale : 800 px"
+  }
+}

--- a/widget/widgetAssets/locales/ja.json
+++ b/widget/widgetAssets/locales/ja.json
@@ -1,5 +1,5 @@
 {
-    "fsmAlertDetials": {
+    "fieldsOfInterest": {
         "HIDE_EMPTY_FIELDS": "空のフィールドを非表示",
         "Hide_EMPTY_FIELDS_TOOLTIP":"チェックすると、すべての空のフィールドが非表示になります。",
         

--- a/widget/widgetAssets/locales/ko.json
+++ b/widget/widgetAssets/locales/ko.json
@@ -1,5 +1,5 @@
 {
-    "fsmAlertDetials": {
+    "fieldsOfInterest": {
         "HIDE_EMPTY_FIELDS": "비어 있는 필드 숨기기",
         "Hide_EMPTY_FIELDS_TOOLTIP": "체크하면 모든 빈 필드が 숨겨집니다.",
         

--- a/widget/widgetAssets/locales/zh_cn.json
+++ b/widget/widgetAssets/locales/zh_cn.json
@@ -1,5 +1,5 @@
 {
-    "fsmAlertDetials": {
+    "fieldsOfInterest": {
         "HIDE_EMPTY_FIELDS": "隐藏空字段",
         "Hide_EMPTY_FIELDS_TOOLTIP": "如果选中，所有空字段将被隐藏。",
         

--- a/widget/widgetAssets/locales/zh_tw.json
+++ b/widget/widgetAssets/locales/zh_tw.json
@@ -1,5 +1,5 @@
 {
-    "fsmAlertDetials": {
+    "fieldsOfInterest": {
         "HIDE_EMPTY_FIELDS": "隱藏空白欄位",
         "Hide_EMPTY_FIELDS_TOOLTIP": "如果勾選，所有空欄位將被隱藏。",
         


### PR DESCRIPTION
- 1274557 | Alert details empty fields are not populating correctly on UI
   - `RCA`:  Wrong name in i18n json files
   - `Solution`: Updated the widget name `fsmAlertDetials` to `fieldsOfInterest` in i18n json files

- Added fr_fr.json 
